### PR TITLE
Cloud watch log stream name per pod. Closes #6.

### DIFF
--- a/marketplace/config/settings/base.py
+++ b/marketplace/config/settings/base.py
@@ -114,22 +114,17 @@ LOGGING = {
 
 if CW_AWS_ACCESS_KEY_ID:
     print('Configuring watchtower logging.')
-    NAMESPACE = 'unknown'
+    POD_NAME = ENVIRONMENT.get_value('APP_POD_NAME', default='local')
     try:
         BOTO3_SESSION = Session(aws_access_key_id=CW_AWS_ACCESS_KEY_ID,
                                 aws_secret_access_key=CW_AWS_SECRET_ACCESS_KEY,
                                 region_name=CW_AWS_REGION)
-        try:
-            with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
-                NAMESPACE = f.read()
-        except Exception:  # pylint: disable=W0703
-            pass
         WATCHTOWER_HANDLER = {
             'level': LOGGING_LEVEL,
             'class': 'watchtower.CloudWatchLogHandler',
             'boto3_session': BOTO3_SESSION,
             'log_group': CW_LOG_GROUP,
-            'stream_name': NAMESPACE,
+            'stream_name': POD_NAME,
             'formatter': LOGGING_FORMATTER,
         }
         LOGGING['handlers']['watchtower'] = WATCHTOWER_HANDLER


### PR DESCRIPTION
* Use pod name instead of namespace
* Get pod name from ENV: https://github.com/RedHatInsights/e2e-deploy/pull/927


Related to: https://github.com/RedHatInsights/marketplace-processor/issues/6