### PR TITLE
Handle bug where objectstore tls value is a boolean not a string.

### DIFF
--- a/marketplace/config/settings/configurator.py
+++ b/marketplace/config/settings/configurator.py
@@ -289,6 +289,8 @@ class ClowderConfigurator(Configurator):
     def get_object_store_tls():
         """Obtain object store secret key."""
         value = LoadedConfig.objectStore.tls
+        if type(value) == bool:
+            return value
         if value and value.lower() in ["true", "false"]:
             value = value.lower() == "true"
         else:


### PR DESCRIPTION
* Deploying to stage the objectstore tls value is a boolean not a string.