### PR TITLE
Include haberdasher in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,13 @@ RUN virtualenv ${APP_ROOT} && \
     rpm-file-permissions && \
     $STI_SCRIPTS_PATH/assemble
 
+RUN curl -L -o /usr/bin/haberdasher \
+https://github.com/RedHatInsights/haberdasher/releases/latest/download/haberdasher_linux_amd64 && \
+chmod 755 /usr/bin/haberdasher
+
 USER 1001
+
+ENTRYPOINT ["/usr/bin/haberdasher"]
 
 # Set the default CMD
 CMD $STI_SCRIPTS_PATH/run


### PR DESCRIPTION
Include haberdasher to use platform logging functionality.

Related: https://github.com/RedHatInsights/insights-rbac/blob/7dfd939ce074cee3690595933978c4d73db1670b/Dockerfile#L66-L72