### PR TITLE
Add script for testing more concurrent payload processing

### DIFF
--- a/scripts/send_gen_files.sh
+++ b/scripts/send_gen_files.sh
@@ -1,0 +1,19 @@
+#!/bin/zsh
+
+PAYLOAD_COUNT=$1
+SAMPLE_DIR=./temp
+
+repeat $PAYLOAD_COUNT do sleep 1; make sample-data; done
+
+ls $SAMPLE_DIR
+
+for entry in "$SAMPLE_DIR"/*
+do
+  echo "$entry"
+  make upload-proxy-data file="$entry"
+done
+
+for entry in "$SAMPLE_DIR"/*
+do
+  rm "$entry"
+done


### PR DESCRIPTION
* Created send_gen_files script which take a number of payloads to generate and send to stage
* reuses the make sample-data mechanism
* reuses the make upload-proxy-data mechanism
* removes all generated files after run